### PR TITLE
Fix ports range for network security groups (#19)

### DIFF
--- a/remediation_worker/jobs/azure_blob_remove_public_access/README.md
+++ b/remediation_worker/jobs/azure_blob_remove_public_access/README.md
@@ -14,10 +14,14 @@ Public read access is enabled for blob storage
 
 ### Prerequisites
 
-The provided Azure service principal must have permissions to make changes to the storage account
+The provided Azure service principal must have the following permissions:
+`Microsoft.Storage/storageAccounts/blobServices/containers/read`
+`Microsoft.Storage/storageAccounts/blobServices/containers/write`
 
-Details for the permissions can be found [here](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-account-contributor):
+A sample role with requisite permissions can be found [here](minimum_permissions.json)
 
+More information about already builtin roles and permissions can be found
+[here](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles)
 
 ### Running the script
 

--- a/remediation_worker/jobs/azure_blob_remove_public_access/minimum_permissions.json
+++ b/remediation_worker/jobs/azure_blob_remove_public_access/minimum_permissions.json
@@ -1,0 +1,19 @@
+{
+  "properties": {
+    "roleName": "remediate_blob_public_access",
+    "description": "This role has required permissions to make changes to the blob containers",
+    "assignableScopes": [
+    ],
+    "permissions": [
+      {
+        "actions": [
+          "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+          "Microsoft.Storage/storageAccounts/blobServices/containers/write"
+        ],
+        "notActions": [],
+        "dataActions": [],
+        "notDataActions": []
+      }
+    ]
+  }
+}

--- a/remediation_worker/jobs/azure_network_security_group_close_port_22/README.md
+++ b/remediation_worker/jobs/azure_network_security_group_close_port_22/README.md
@@ -14,10 +14,14 @@ The security group allows access to SSH port (22)
 
 ### Prerequisites
 
-The provided Azure service principal must have permissions to make changes to the network security groups and security
-rules.
-Details for the permissions can be found [here](https://docs.microsoft.com/en-us/azure/virtual-network/manage-network-security-group#permissions):
+The provided Azure service principal must have the following permissions:
+`Microsoft.Network/networkSecurityGroups/read`
+`Microsoft.Network/networkSecurityGroups/write`
 
+A sample role with requisite permissions can be found [here](minimum_permissions.json)
+
+More information about already builtin roles and permissions can be found
+[here](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles)
 
 ### Running the script
 

--- a/remediation_worker/jobs/azure_network_security_group_close_port_22/azure_network_security_group_close_port_22.py
+++ b/remediation_worker/jobs/azure_network_security_group_close_port_22/azure_network_security_group_close_port_22.py
@@ -105,7 +105,15 @@ class NetworkSecurityGroupClosePort22(object):
             ):
                 continue
             if rule.destination_port_range is not None:
-                if int(rule.destination_port_range) == port:
+                port_range = rule.destination_port_range
+                if "-" in port_range:
+                    new_ranges = self._find_and_remove_port([port_range], port)
+                    if len(new_ranges) == 1:
+                        rule.destination_port_range = new_ranges[0]
+                    else:
+                        rule.destination_port_range = None
+                        rule.destination_port_ranges = new_ranges
+                elif int(rule.destination_port_range) == port:
                     security_rules.remove(rule)
             else:
                 port_ranges = rule.destination_port_ranges

--- a/remediation_worker/jobs/azure_network_security_group_close_port_22/minimum_permissions.json
+++ b/remediation_worker/jobs/azure_network_security_group_close_port_22/minimum_permissions.json
@@ -1,0 +1,19 @@
+{
+  "properties": {
+    "roleName": "remediate_network_security_group",
+    "description": "This role has required permissions to make changes in the network security groups",
+    "assignableScopes": [
+    ],
+    "permissions": [
+      {
+        "actions": [
+          "Microsoft.Network/networkSecurityGroups/read",
+          "Microsoft.Network/networkSecurityGroups/write"
+        ],
+        "notActions": [],
+        "dataActions": [],
+        "notDataActions": []
+      }
+    ]
+  }
+}

--- a/remediation_worker/jobs/azure_network_security_group_close_port_3389/README.md
+++ b/remediation_worker/jobs/azure_network_security_group_close_port_3389/README.md
@@ -14,9 +14,14 @@ The security group allows access to Remote Desktop port (3389)
 
 ### Prerequisites
 
-The provided Azure service principal must have permissions to make changes to the network security groups and security
-rules.
-Details for the permissions can be found [here](https://docs.microsoft.com/en-us/azure/virtual-network/manage-network-security-group#permissions):
+The provided Azure service principal must have the following permissions:
+`Microsoft.Network/networkSecurityGroups/read`
+`Microsoft.Network/networkSecurityGroups/write`
+
+A sample role with requisite permissions can be found [here](minimum_permissions.json)
+
+More information about already builtin roles and permissions can be found
+[here](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles)
 
 
 ### Running the script

--- a/remediation_worker/jobs/azure_network_security_group_close_port_3389/azure_network_security_group_close_port_3389.py
+++ b/remediation_worker/jobs/azure_network_security_group_close_port_3389/azure_network_security_group_close_port_3389.py
@@ -102,7 +102,15 @@ class NetworkSecurityGroupClosePort3389(object):
             ):
                 continue
             if rule.destination_port_range is not None:
-                if int(rule.destination_port_range) == port:
+                port_range = rule.destination_port_range
+                if "-" in port_range:
+                    new_ranges = self._find_and_remove_port([port_range], port)
+                    if len(new_ranges) == 1:
+                        rule.destination_port_range = new_ranges[0]
+                    else:
+                        rule.destination_port_range = None
+                        rule.destination_port_ranges = new_ranges
+                elif int(rule.destination_port_range) == port:
                     security_rules.remove(rule)
             else:
                 port_ranges = rule.destination_port_ranges

--- a/remediation_worker/jobs/azure_network_security_group_close_port_3389/minimum_permissions.json
+++ b/remediation_worker/jobs/azure_network_security_group_close_port_3389/minimum_permissions.json
@@ -1,0 +1,19 @@
+{
+  "properties": {
+    "roleName": "remediate_network_security_group",
+    "description": "This role has required permission to make changes in the network security groups",
+    "assignableScopes": [
+    ],
+    "permissions": [
+      {
+        "actions": [
+          "Microsoft.Network/networkSecurityGroups/read",
+          "Microsoft.Network/networkSecurityGroups/write"
+        ],
+        "notActions": [],
+        "dataActions": [],
+        "notDataActions": []
+      }
+    ]
+  }
+}

--- a/remediation_worker/jobs/azure_storage_account_allow_https_traffic_only/README.md
+++ b/remediation_worker/jobs/azure_storage_account_allow_https_traffic_only/README.md
@@ -15,10 +15,14 @@ Secure connections are not enabled for storage transactions
 
 ### Prerequisites
 
-The provided Azure service principal must have permissions to make changes to the storage accounts.
+The provided Azure service principal must have the following permissions:
+`Microsoft.Storage/storageAccounts/read`
+`Microsoft.Storage/storageAccounts/write`
 
-Details for the permissions can be found [here](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-account-contributor):
+A sample role with requisite permissions can be found [here](minimum_permissions.json)
 
+More information about already builtin roles and permissions can be found
+[here](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles)
 
 ### Running the script
 

--- a/remediation_worker/jobs/azure_storage_account_allow_https_traffic_only/minimum_permissions.json
+++ b/remediation_worker/jobs/azure_storage_account_allow_https_traffic_only/minimum_permissions.json
@@ -1,0 +1,19 @@
+{
+  "properties": {
+    "roleName": "remediate_storage_account",
+    "description": "This role has required permissions to make changes to the storage account",
+    "assignableScopes": [
+    ],
+    "permissions": [
+      {
+        "actions": [
+          "Microsoft.Storage/storageAccounts/write",
+          "Microsoft.Storage/storageAccounts/read"
+        ],
+        "notActions": [],
+        "dataActions": [],
+        "notDataActions": []
+      }
+    ]
+  }
+}

--- a/remediation_worker/jobs/azure_vm_close_port_22/README.md
+++ b/remediation_worker/jobs/azure_vm_close_port_22/README.md
@@ -14,10 +14,16 @@ A virtual machine is publicly accessible to the internet via port 22
 
 ### Prerequisites
 
-The provided Azure service principal must have permissions to make changes to the network security groups and security
-rules.
-Details for the permissions can be found [here](https://docs.microsoft.com/en-us/azure/virtual-network/manage-network-security-group#permissions):
+The provided Azure service principal must have the following permissions:
+`Microsoft.Compute/virtualMachines/read`
+`Microsoft.Network/networkInterfaces/read`
+`Microsoft.Network/networkSecurityGroups/read`
+`Microsoft.Network/networkSecurityGroups/write`
 
+A sample role with requisite permissions can be found [here](minimum_permissions.json)
+
+More information about already builtin roles and permissions can be found
+[here](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles)
 
 ### Running the script
 

--- a/remediation_worker/jobs/azure_vm_close_port_22/minimum_permissions.json
+++ b/remediation_worker/jobs/azure_vm_close_port_22/minimum_permissions.json
@@ -1,0 +1,21 @@
+{
+  "properties": {
+    "roleName": "remediate_vm",
+    "description": "This role has required permissions Role with permissions to remediate VM violations for port 22",
+    "assignableScopes": [
+    ],
+    "permissions": [
+      {
+        "actions": [
+          "Microsoft.Compute/virtualMachines/read",
+          "Microsoft.Network/networkInterfaces/read",
+          "Microsoft.Network/networkSecurityGroups/read",
+          "Microsoft.Network/networkSecurityGroups/write"
+        ],
+        "notActions": [],
+        "dataActions": [],
+        "notDataActions": []
+      }
+    ]
+  }
+}

--- a/test/unit/test_azure_network_security_group_close_port_22.py
+++ b/test/unit/test_azure_network_security_group_close_port_22.py
@@ -58,14 +58,14 @@ class TestNetworkSecurityGroupClosePort22(object):
                     access="Allow",
                     direction="Inbound",
                     source_address_prefix="*",
-                    destination_port_ranges=["22", "3389"],
+                    destination_port_ranges=["22-30", "3389"],
                 ),
                 SecurityRule(
                     protocol="All",
                     access="Allow",
                     direction="Inbound",
                     source_address_prefix="*",
-                    destination_port_ranges=["20-30", "3389"],
+                    destination_port_range="20-30",
                 ),
                 SecurityRule(
                     protocol="All",
@@ -73,6 +73,13 @@ class TestNetworkSecurityGroupClosePort22(object):
                     direction="Inbound",
                     source_address_prefix="*",
                     destination_port_range="22",
+                ),
+                SecurityRule(
+                    protocol="All",
+                    access="Allow",
+                    direction="Inbound",
+                    source_address_prefix="*",
+                    destination_port_range="35",
                 ),
             ],
         )
@@ -84,9 +91,11 @@ class TestNetworkSecurityGroupClosePort22(object):
         call_args = client.network_security_groups.create_or_update.call_args
         updated_sg = call_args.args[2]
         security_rules = updated_sg.security_rules
-        assert len(security_rules) == 2
-        assert security_rules[0].destination_port_ranges == ["3389"]
-        assert security_rules[1].destination_port_ranges == ["20-21", "23-30", "3389"]
+        assert len(security_rules) == 3
+        assert security_rules[0].destination_port_ranges == ["23-30","3389"]
+        assert security_rules[1].destination_port_ranges == ["20-21", "23-30"]
+        assert security_rules[1].destination_port_range is None
+        assert security_rules[2].destination_port_range == "35"
 
     def test_remediate_with_exception(self):
         client = Mock()

--- a/test/unit/test_azure_network_security_group_close_port_3389.py
+++ b/test/unit/test_azure_network_security_group_close_port_3389.py
@@ -59,14 +59,14 @@ class TestNetworkSecurityGroupClosePort22(object):
                     access="Allow",
                     direction="Inbound",
                     source_address_prefix="*",
-                    destination_port_ranges=["22", "3389"],
+                    destination_port_ranges=["22-30", "3380-3390"],
                 ),
                 SecurityRule(
                     protocol="All",
                     access="Allow",
                     direction="Inbound",
                     source_address_prefix="*",
-                    destination_port_ranges=["20-30", "3380-3390"],
+                    destination_port_range="3380-3395",
                 ),
                 SecurityRule(
                     protocol="All",
@@ -74,6 +74,13 @@ class TestNetworkSecurityGroupClosePort22(object):
                     direction="Inbound",
                     source_address_prefix="*",
                     destination_port_range="3389",
+                ),
+                SecurityRule(
+                    protocol="All",
+                    access="Allow",
+                    direction="Inbound",
+                    source_address_prefix="*",
+                    destination_port_range="35",
                 ),
             ],
         )
@@ -85,9 +92,11 @@ class TestNetworkSecurityGroupClosePort22(object):
         call_args = client.network_security_groups.create_or_update.call_args
         updated_sg = call_args.args[2]
         security_rules = updated_sg.security_rules
-        assert len(security_rules) == 2
-        assert security_rules[0].destination_port_ranges == ["22"]
-        assert security_rules[1].destination_port_ranges == ["20-30", "3380-3388", "3390"]
+        assert len(security_rules) == 3
+        assert security_rules[0].destination_port_ranges == ["22-30", "3380-3388", "3390"]
+        assert security_rules[1].destination_port_ranges == ["3380-3388", "3390-3395"]
+        assert security_rules[1].destination_port_range is None
+        assert security_rules[2].destination_port_range == "35"
 
     def test_remediate_with_exception(self):
         client = Mock()


### PR DESCRIPTION
* handle the case when the security rule port is a range

* Add minimum permissions for each remediation jobs

* add link to built in roles

Co-authored-by: Mohammad Zuber Khan <khanz@vmware.com>